### PR TITLE
Feature/generate site

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,11 @@
+2016-11-02
+
+The previous refactoring constituted version 3.0.
+Now it's clear that this module can be even simpler and easier to use
+by using a convention that I will encapsulate in a new method:
+
+* generateSite(sourceDirectory, destinationDirectory, [options], [callback]) => Promise
+
 2016-10-09
 
 Refactoring to separate processing into three distinct phases:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,30 @@ then you can include it with the syntax `{{>theme/navigation}}`.
 
 ## API
 
+### generateSite(sourcePath, distPath, [options], [callback])
+
+* `sourcePath` {String} the path of the directory containing templates
+* `distPath` {String} the path of the output directory, where page templates will be rendered as files
+* `options` {Object} (optional)
+    * `sourceExtension` {String} (default: "html") the file extension for templates (source files)
+    * `distExtension` {String} (default: "html") the file extension for pages (output files)
+* `callback` {Function} (optional) the asynchronous callback function (returns promise if not given)
+
+Generating a site means rendering page templates in a source directory and writing page output to files in a destination directory:
+
+* Put template files in the source directory.
+* Every template will be registered as a partial.
+* Make a template be registered as a page template by creating a corresponding ".js" file.
+    * For example, suppose your source directory is "./src", and a file exists in the path "./src/faq.html":
+    * Create "./src/faq.js" that exports data (an Object).
+    * The existence of the "js" file will the template to be registered as a page and rendered with the data that it exports.
+* Every page template in the source directory will be written to the same relative path in the destination directory.
+* Global data (available to every page) is whatever is exported by "./src/index.js" (assuming "./src" is your source path)
+* Global data also includes a variable called "pagePath" whose value is the relative path of the current page template being rendered.
+
+
+## Lower-Level API
+
 ### registerSourceDirectory(path, options)
 
 * `path` {String} the name of the directory containing templates

--- a/lib/handlebars-generator.js
+++ b/lib/handlebars-generator.js
@@ -4,6 +4,7 @@ var Handlebars = require('handlebars');
 var SourceDirectory = require('./source-directory');
 var PageProcessor = require('./page-processor');
 var DestinationDirectory = require('./destination-directory');
+var SiteUtil = require('./site-util');
 
 function constructor(handlebars) {
 	this.handlebars = handlebars || Handlebars;
@@ -18,7 +19,8 @@ constructor.prototype = {
 	registerPage: registerPage,
 	registerPageFactory: registerPageFactory,
 	registerDataFactory: registerDataFactory,
-	generatePages: generatePages
+	generatePages: generatePages,
+	generateSite: generateSite
 };
 
 function create(handlebars) {
@@ -68,6 +70,33 @@ function generatePages(distPath, options, callback) {
 	else {
 		return promise;
 	}
+}
+
+function generateSite(sourcePath, distPath, options, callback) {
+
+	// reassign parameters in case of signature (sourceDirectory, destinationDirectory, callback)
+	if (!callback && typeof options === 'function') {
+		callback = options;
+		options = null;
+	}
+
+	options = _.defaults({
+		sourceExtension: 'html',
+		distExtension: 'html'
+	}, options);
+
+	var siteUtil = SiteUtil({
+		sourcePath: sourcePath
+	});
+
+	this.registerSourceDirectory(sourcePath, {extension: options.sourceExtension});
+	this.registerPageFactory(siteUtil.pageFactory);
+	this.registerDataFactory(siteUtil.dataFactory);
+	this.registerDataFactory(siteUtil.siteDataFactory);
+	this.registerDataFactory(siteUtil.pageDataFactory);
+
+	return this.generatePages(distPath, {extension: options.distExtension}, callback);
+
 }
 
 module.exports = new constructor();

--- a/lib/site-util.js
+++ b/lib/site-util.js
@@ -1,10 +1,11 @@
 var assert = require('assert');
 var fs = require('fs');
+var Path = require('path');
 
 function SiteUtil(options) {
 	assert(options, 'requires options');
 	assert(options.sourcePath, 'requires options.sourcePath');
-	var sourcePath = fixPath(options.sourcePath);
+	var sourcePath = Path.resolve(process.cwd(), options.sourcePath);
 
 	return {
 		pageFactory: pageFactory,
@@ -47,15 +48,6 @@ function SiteUtil(options) {
 		return requireFile(sourcePath + '/' + outputFile + '.js');
 	}
 
-}
-
-function fixPath(path) {
-	if (path.indexOf('/') === 0) {
-		return path;
-	}
-	else {
-		return './' + path;
-	}
 }
 
 function requireFile(path) {

--- a/lib/site-util.js
+++ b/lib/site-util.js
@@ -1,0 +1,74 @@
+var assert = require('assert');
+var fs = require('fs');
+
+function SiteUtil(options) {
+	assert(options, 'requires options');
+	assert(options.sourcePath, 'requires options.sourcePath');
+	var sourcePath = fixPath(options.sourcePath);
+
+	return {
+		pageFactory: pageFactory,
+		dataFactory: dataFactory,
+		pageDataFactory: pageDataFactory,
+		siteDataFactory: siteDataFactory
+	};
+
+	/**
+	 * Identifies page templates according to whether there is a corresponding ".js" file for it
+	 */
+	function pageFactory(filePath) {
+		var jsFilePath = sourcePath + '/' + filePath + '.js';
+		if (fs.existsSync(jsFilePath)) {
+			return filePath;
+		}
+	}
+
+	/**
+	 * Provides contextual data for every page.
+	 */
+	function dataFactory(outputFile) {
+		return {
+			pagePath: outputFile
+		};
+	}
+
+	/**
+	 * Provides the universal data for all pages.
+	 */
+	function siteDataFactory(outputFile) {
+		// not using outputFile (yet) because "site data" is the same for every generated page (for now)
+		return requireFile(sourcePath + '/index.js');
+	}
+
+	/**
+	 * Provides the page specific data.
+	 */
+	function pageDataFactory(outputFile) {
+		return requireFile(sourcePath + '/' + outputFile + '.js');
+	}
+
+}
+
+function fixPath(path) {
+	if (path.indexOf('/') === 0) {
+		return path;
+	}
+	else {
+		return './' + path;
+	}
+}
+
+function requireFile(path) {
+	var data;
+	if (fs.existsSync(path)) {
+		try {
+			data = require(path);
+		}
+		catch (e) {
+			console.error('unable to require path ' + path);
+		}
+	}
+	return data;
+}
+
+module.exports = SiteUtil;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handlebars-generator",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Handlebars template bulk compiler to help generate static sites",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adding a higher-level "generateSite" method to be used instead of any of the now lower-level methods, because it provides a set of conventions that should be easy to learn and convenient to use.